### PR TITLE
Do not match with boolean

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -5,7 +5,7 @@ const deepEqual = require('fast-deep-equal')
 const getHttpError = require('./httpErrors').getHttpError
 
 function assert (condition, code, message) {
-  if (condition === true) return
+  if (condition) return
   throw getHttpError(code, message)
 }
 


### PR DESCRIPTION
The provided example `fastify.assert(req.headers.authorization, 400)` won't work this way because the string as a header was compared with a boolean. With this PR, it will behave the exact way as the `http-assert` package and allow any truthy value.