### PR TITLE
feat(typescript): add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,84 @@
+import * as fastify from "fastify";
+import * as http from "http";
+import { HttpErrors } from "./lib/httpError";
+
+declare module "fastify" {
+  namespace SensibleTypes {
+    type ToType<T> = [Error, T];
+    type Address = "loopback" | "linklocal" | "uniquelocal" | string;
+  }
+
+  interface Assert {
+    (condition: boolean, code?: number | string, message?: string): string;
+    ok(condition: boolean, code?: number | string, message?: string): string;
+    equal<T, U>(a: T, b: U, code?: number | string, message?: string): string;
+    notEqual<T, U>(
+      a: T,
+      b: U,
+      code?: number | string,
+      message?: string
+    ): string;
+    strictEqual<T, U>(
+      a: T,
+      b: U,
+      code?: number | string,
+      message?: string
+    ): string;
+    notStrictEqual<T, U>(
+      a: T,
+      b: U,
+      code?: number | string,
+      message?: string
+    ): string;
+    deepEqual<T, U>(
+      a: T,
+      b: U,
+      code?: number | string,
+      message?: string
+    ): string;
+    notDeepEqual<T, U>(
+      a: T,
+      b: U,
+      code?: number | string,
+      message?: string
+    ): string;
+  }
+
+  interface To {
+    <T>(to: Promise<T>): Promise<SensibleTypes.ToType<T>>;
+  }
+
+  interface FastifyInstance extends HttpErrors {
+    assert: Assert;
+    to: To;
+  }
+
+  interface FastifyReply<HttpResponse> {
+    vary: {
+      (field: string | string[]): void;
+      append: (header: string, field: string | string[]) => string;
+    };
+  }
+
+  interface FastifyRequest<HttpRequest> {
+    forwarded(): string[];
+    proxyaddr(
+      trust:
+        | SensibleTypes.Address
+        | SensibleTypes.Address[]
+        | ((addr: string, i: number) => boolean)
+    ): string;
+    is(types: Array<string>): string | false | null;
+    is(...types: Array<string>): string | false | null;
+  }
+}
+
+declare const fastifySensible: fastify.Plugin<
+  http.Server,
+  http.IncomingMessage,
+  http.ServerResponse,
+  {}
+>;
+
+export { HttpErrorType } from "./lib/httpError";
+export default fastifySensible;

--- a/lib/httpError.d.ts
+++ b/lib/httpError.d.ts
@@ -1,0 +1,68 @@
+interface Error {
+  stack?: string;
+}
+
+interface HttpError extends Error {
+  status: number;
+  statusCode: number;
+  expose: boolean;
+  headers?: {
+      [key: string]: string;
+  };
+  [key: string]: any;
+}
+
+type HttpErrorConstructor = new (msg?: string) => HttpError;
+
+export type HttpErrorType = {
+    badRequest(message?: string): HttpError;
+    unauthorized(message?: string): HttpError;
+    paymentRequired(message?: string): HttpError;
+    forbidden(message?: string): HttpError;
+    notFound(message?: string): HttpError;
+    methodNotAllowed(message?: string): HttpError;
+    notAcceptable(message?: string): HttpError;
+    proxyAuthenticationRequired(message?: string): HttpError;
+    requestTimeout(message?: string): HttpError;
+    conflict(message?: string): HttpError;
+    gone(message?: string): HttpError;
+    lengthRequired(message?: string): HttpError;
+    preconditionFailed(message?: string): HttpError;
+    payloadTooLarge(message?: string): HttpError;
+    uriTooLong(message?: string): HttpError;
+    unsupportedMediaType(message?: string): HttpError;
+    rangeNotSatisfiable(message?: string): HttpError;
+    expectationFailed(message?: string): HttpError;
+    imateapot(message?: string): HttpError;
+    misdirectedRequest(message?: string): HttpError;
+    unprocessableEntity(message?: string): HttpError;
+    locked(message?: string): HttpError;
+    failedDependency(message?: string): HttpError;
+    unorderedCollection(message?: string): HttpError;
+    upgradeRequired(message?: string): HttpError;
+    preconditionRequired(message?: string): HttpError;
+    tooManyRequests(message?: string): HttpError;
+    requestHeaderFieldsTooLarge(message?: string): HttpError;
+    unavailableForLegalReasons(message?: string): HttpError;
+    internalServerError(message?: string): HttpError;
+    notImplemented(message?: string): HttpError;
+    badGateway(message?: string): HttpError;
+    serviceUnavailable(message?: string): HttpError;
+    gatewayTimeout(message?: string): HttpError;
+    httpVersionNotSupported(message?: string): HttpError;
+    variantAlsoNegotiates(message?: string): HttpError;
+    insufficientStorage(message?: string): HttpError;
+    loopDetected(message?: string): HttpError;
+    bandwidthLimitExceeded(message?: string): HttpError;
+    notExtended(message?: string): HttpError;
+    networkAuthenticationRequired(
+      message?: string,
+    ): HttpError;
+
+    getHttpError: (code?: number | string, message?: string) => string;
+    HttpError: HttpErrorConstructor;
+};
+
+export interface HttpErrors {
+    httpError: HttpErrorType;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Defaults for Fastify that everyone can agree on",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap test/*.test.js"
+    "test": "standard && tap test/*.test.js && tsc --project ./tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tap": "^12.1.1"
   },
   "dependencies": {
+    "@types/node": "^12.0.7",
     "fast-deep-equal": "^2.0.1",
     "fastify-plugin": "^1.3.0",
     "forwarded": "^0.1.2",

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,168 @@
+import * as fastify from "fastify";
+import fastifySensible from "../index";
+
+const app = fastify();
+
+app.register(fastifySensible);
+
+// 'assert' types test
+app.ready(err => {
+  try {
+    app.assert(true);
+    app.assert(true, 400);
+    app.assert(true, "400");
+    app.assert(true, 400, "Bad request");
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.ok(true);
+    app.assert.ok(true, 400);
+    app.assert.ok(true, "400");
+    app.assert.ok(true, 400, "Bad request");
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.equal(1, "1");
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.notEqual(1, "2");
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.strictEqual(1, 1);
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.notStrictEqual(1, 2);
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.deepEqual({ hello: "world" }, { hello: "world" });
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.notDeepEqual({ hello: "world" }, { hello: "dlrow" });
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.deepEqual({ hello: "world" }, { hello: "world" });
+  } catch (err) {
+    throw err;
+  }
+});
+
+app.ready(err => {
+  try {
+    app.assert.deepEqual({ hello: "world" }, { hello: "world" });
+  } catch (err) {
+    throw err;
+  }
+});
+
+// 'errorHandler' types test
+app.get("/", (req, reply) => {
+  reply.send(new Error("kaboom"));
+});
+
+// 'forwarded' types test
+app.get("/", (req, reply) => {
+  reply.send(req.forwarded());
+});
+
+// 'httpError' types test
+app.addHook("preHandler", async (request, reply) => {
+  try {
+    await app.httpError.getHttpError(400);
+    await app.httpError.badGateway();
+  } catch {
+    const err = app.httpError["imateapot"]("custom");
+    reply.send(err);
+  }
+});
+
+app.addHook("onError", (request, reply, error, next) => {
+  const err = app.httpError["imateapot"]("custom");
+  reply.send(err);
+});
+
+// 'is' types test
+app.get("/", (req, reply) => {
+  reply.send(req.is("json"));
+});
+
+app.get("/", (req, reply) => {
+  reply.send(req.is(["html", "json"]));
+});
+
+// 'proxyaddr' types test
+app.get("/", (req, reply) => {
+  reply.send(req.proxyaddr(addr => addr === "127.0.0.1"));
+});
+
+app.get("/test", (req, reply) => {
+  reply.send(req.proxyaddr(["127.0.0.0/8", "10.0.0.0/8"]));
+});
+
+// 'to' types test
+app.ready(err => {
+  app.to(promise(true)).then(val => {});
+});
+
+function promise(bool: boolean) {
+  return new Promise((resolve, reject) => {
+    if (bool) {
+      resolve(true);
+    } else {
+      reject(new Error("kaboom"));
+    }
+  });
+}
+
+// 'vary' types test
+app.get("/", (req, reply) => {
+  reply.vary("Accept");
+  reply.vary("Origin");
+  reply.vary("User-Agent");
+  reply.send("ok");
+});
+
+app.get("/", (req, reply) => {
+  app.assert.strictEqual(
+    reply.vary.append("", ["Accept", "Accept-Language"]),
+    "Accept, Accept-Language"
+  );
+  reply.send("ok");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "extendedDiagnostics": true
+  },
+  "files": [
+    "./test/types.test.ts"
+  ]
+}


### PR DESCRIPTION
The default export is the fastifySensible plugin, whereas the http
errors are also being namely exported on index.d.ts.

The need came from a project using TypeScript, in which we would
like to augment fastify plugin using fastify-sensible's httpErrors. Thus,
needing the definitions.