### PR TITLE
imateapot normalize is missing

### DIFF
--- a/lib/httpErrors.js
+++ b/lib/httpErrors.js
@@ -10,6 +10,7 @@ Object.keys(statusCodesMap).forEach(code => {
 
 function normalize (code, msg) {
   if (code === '414') return 'uriTooLong'
+  if (code === '418') return 'imateapot'
   if (code === '505') return 'httpVersionNotSupported'
   msg = msg.split(' ').join('').replace(/'/g, '')
   msg = msg[0].toLowerCase() + msg.slice(1)


### PR DESCRIPTION
`if (code === '418') return 'imateapot'` is present in tests but not in this file;
generated name is imaTeapot, causing `getHttpError(418)` to be undefined;

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
