### PR TITLE
 fix: add missing createError type definition

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,6 +12,10 @@ app.get('/', (req, reply) => {
   expectAssignable<void>(reply.notFound())
 })
 
+app.get('/', (req, reply) => {
+  expectAssignable<Error>(app.httpErrors.createError(405, 'Method Not Allowed'))
+})
+
 app.get('/', async (req, reply) => {
   expectAssignable<Error>(app.httpErrors.notFound())
 })

--- a/lib/httpError.d.ts
+++ b/lib/httpError.d.ts
@@ -8,6 +8,8 @@ interface HttpError extends Error {
   [key: string]: any;
 }
 
+type UnknownError = Error | string | number | { [key: string]: any };
+
 type HttpErrorCodes = 400 | '400' // BadRequest
                     | 401 | '401' // Unauthorized
                     | 402 | '402' // PaymentRequired
@@ -95,6 +97,7 @@ type HttpErrorNames = 'badRequest'
 export type HttpErrors = {
   HttpError: HttpError;
   getHttpError: (code: HttpErrorCodes, message?: string) => HttpError;
+  createError: (...args: UnknownError[]) => HttpError;
 } & Record<HttpErrorNames, (msg?: string) => HttpError>;
 
 export type HttpErrorReplys = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hey 👋, found the type definition `createError` missing. I checked the types from `http-errors` and used them.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
