### PR TITLE
Faster initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const vary = require('./lib/vary')
 const cache = require('./lib/cache-control')
 
 function fastifySensible (fastify, opts, next) {
-  console.time()
   fastify.decorate('httpErrors', httpErrors)
   fastify.decorate('assert', assert)
   fastify.decorate('to', to)
@@ -58,7 +57,6 @@ function fastifySensible (fastify, opts, next) {
     return promise.then(data => [null, data], err => [err, undefined])
   }
 
-  console.timeEnd()
   next()
 }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const vary = require('./lib/vary')
 const cache = require('./lib/cache-control')
 
 function fastifySensible (fastify, opts, next) {
+  console.time()
   fastify.decorate('httpErrors', httpErrors)
   fastify.decorate('assert', assert)
   fastify.decorate('to', to)
@@ -31,8 +32,10 @@ function fastifySensible (fastify, opts, next) {
   fastify.decorateReply('stale', cache.stale)
   fastify.decorateReply('maxAge', cache.maxAge)
 
-  // TODO: benchmark if this closure causes some performance drop
-  Object.keys(httpErrors).forEach(httpError => {
+  const httpErrorsKeys = Object.keys(httpErrors)
+  for (let i = 0; i < httpErrorsKeys.length; ++i) {
+    const httpError = httpErrorsKeys[i]
+
     switch (httpError) {
       case 'HttpError':
         // skip abstract class constructor
@@ -49,12 +52,13 @@ function fastifySensible (fastify, opts, next) {
           return this
         })
     }
-  })
+  }
 
   function to (promise) {
     return promise.then(data => [null, data], err => [err, undefined])
   }
 
+  console.timeEnd()
   next()
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "npm run lint && npm run test:unit && npm run test:typescript",
+    "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "tap"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "npm run test:unit && npm run test:typescript",
+    "test": "npm run lint && npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "tap"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "lint": "standard",
+    "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "tap"
@@ -27,6 +28,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-sensible#readme",
   "devDependencies": {
+    "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
     "fastify": "^4.0.0-rc.2",
     "standard": "^17.0.0",

--- a/test/cache-control.test.js
+++ b/test/cache-control.test.js
@@ -69,7 +69,7 @@ test('reply.preventCache API', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers['cache-control'], 'no-store, max-age=0, private')
     t.equal(res.headers.pragma, 'no-cache')
-    t.equal(res.headers.expires, 0)
+    t.equal(res.headers.expires, '0')
     t.equal(res.payload, 'ok')
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

It doesn't amount to much, but I'm consistently seeing faster initialization results with a for loop instead of forEach. I tested the difference very simply by wrapping the whole plugin with `console.time()` and running the tests. With the for loop, the startup almost always takes less then 0.01ms, which otherwise does not happen on my machine

This PR also fixes a test, ~makes linting part of the test suite~, adds the `lint:fix` script as well as `@fastify/pre-commit`

OLD
```shell
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.014ms
test/httpErrorsReply.test.js 1> default: 0.012ms
test/httpErrorsReply.test.js 1> default: 0.011ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.013ms
test/httpErrorsReply.test.js 1> default: 0.014ms
test/httpErrorsReply.test.js 1> default: 0.019ms
test/httpErrorsReply.test.js 1> default: 0.015ms
test/httpErrorsReply.test.js 1> default: 0.011ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.012ms
test/httpErrorsReply.test.js 1> default: 0.011ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.014ms
test/httpErrorsReply.test.js 1> default: 0.011ms
test/httpErrorsReply.test.js 1> default: 0.011ms
test/httpErrorsReply.test.js 1> default: 0.013ms
test/httpErrorsReply.test.js 1> default: 0.014ms
test/httpErrorsReply.test.js 1> default: 0.013ms
test/httpErrorsReply.test.js 1> default: 0.012ms
```

NEW
```shell
test/httpErrorsReply.test.js 1> default: 0.01ms
test/httpErrorsReply.test.js 1> default: 0.009ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.008ms
test/httpErrorsReply.test.js 1> default: 0.012ms
test/httpErrorsReply.test.js 1> default: 0.009ms
test/httpErrorsReply.test.js 1> default: 0.009ms
test/httpErrorsReply.test.js 1> default: 0.009ms
test/httpErrorsReply.test.js 1> default: 0.009ms
test/httpErrorsReply.test.js 1> default: 0.009ms
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
