### PR TITLE
feat: improve type declaration for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ If you set the `sharedSchemaId` option, a shared JSON Schema is added and can be
 ```js
 const fastify = require('fastify')()
 fastify.register(require('@fastify/sensible'), {
-  sharedSchemaId: 'httpError'
+  sharedSchemaId: 'HttpError'
 })
 
 fastify.get('/async', {
   schema: {
     response: {
-      404: { $ref: 'httpError' }
+      404: { $ref: 'HttpError' }
     }
   }
   handler: async (req, reply) => {

--- a/lib/httpError.d.ts
+++ b/lib/httpError.d.ts
@@ -10,7 +10,7 @@ interface HttpError extends Error {
 
 type UnknownError = Error | string | number | { [key: string]: any };
 
-type HttpErrorCodes = 400 | '400' // BadRequest
+export type HttpErrorCodes = 400 | '400' // BadRequest
                     | 401 | '401' // Unauthorized
                     | 402 | '402' // PaymentRequired
                     | 403 | '403' // Forbidden
@@ -52,7 +52,7 @@ type HttpErrorCodes = 400 | '400' // BadRequest
                     | 510 | '510' // NotExtended
                     | 511 | '511' // NetworkAuthenticationRequire
 
-type HttpErrorNames = 'badRequest'
+export type HttpErrorNames = 'badRequest'
                     | 'unauthorized'
                     | 'paymentRequired'
                     | 'forbidden'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,26 @@ declare module 'fastify' {
 
 declare namespace fastifySensible {
   export interface SensibleOptions {
+    /**
+     * You can use this option to register a shared JSON Schema you can use in your routes.
+     * 
+     * @example
+     * ```js
+     * fastify.register(require('@fastify/sensible'), {
+     *   sharedSchemaId: 'httpError'
+     * })
+     *
+     * fastify.get('/async', {
+     *   schema: {
+     *     response: { 404: { $ref: 'httpError' } }
+     *   }
+     *   handler: async (req, reply) => {
+     *     return reply.notFound()
+     *   }
+     * })
+     * ```
+     */
+    sharedSchemaId?: string;
   }
 
   export const fastifySensible: FastifySensible

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,7 +93,6 @@ declare namespace fastifySensible {
   export type HttpErrorCodes = Errors.HttpErrorCodes;
   export type HttpErrorNames = Errors.HttpErrorNames;
 
-
   export type HttpErrorReplys = {
     getHttpError: (code: HttpErrorCodes, message?: string) => FastifyReply;
   } & Record<HttpErrorNames, (msg?: string) => FastifyReply>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginCallback, FastifyReply  } from 'fastify'
 import { HttpErrors, HttpErrorCodes, HttpErrorNames } from "../lib/httpError"
+import * as Errors from '../lib/httpError'
 
 type FastifySensible = FastifyPluginCallback<fastifySensible.SensibleOptions>
 
@@ -89,6 +90,10 @@ declare namespace fastifySensible {
      */
     sharedSchemaId?: string;
   }
+
+  export type HttpErrors = Errors.HttpErrors;
+  export type HttpErrorCodes = Errors.HttpErrorCodes;
+  export type HttpErrorNames = Errors.HttpErrorNames;
 
   export const fastifySensible: FastifySensible
   export { fastifySensible as default }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,25 +4,23 @@ import * as Errors from '../lib/httpError'
 
 type FastifySensible = FastifyPluginCallback<fastifySensible.SensibleOptions>
 
-type singleValueTypes = 'must-revalidate' |
-  'no-cache' |
-  'no-store' |
-  'no-transform' |
-  'public' |
-  'private' |
-  'proxy-revalidate' |
-  'immutable'
+type singleValueTypes =
+  | 'must-revalidate'
+  | 'no-cache'
+  | 'no-store'
+  | 'no-transform'
+  | 'public'
+  | 'private'
+  | 'proxy-revalidate'
+  | 'immutable'
 
-type multiValueTypes = 'max-age' |
-  's-maxage' |
-  'stale-while-revalidate' |
-  'stale-if-error'
+type multiValueTypes =
+  | 'max-age'
+  | 's-maxage'
+  | 'stale-while-revalidate'
+  | 'stale-if-error'
 
 type staleTypes = 'while-revalidate' | 'if-error'
-
-type HttpErrorReplys = {
-  getHttpError: (code: HttpErrorCodes, message?: string) => FastifyReply;
-} & Record<HttpErrorNames, (msg?: string) => FastifyReply>;
 
 declare module 'fastify' {
   namespace SensibleTypes {
@@ -46,7 +44,7 @@ declare module 'fastify' {
     httpErrors: HttpErrors;
   }
 
-  interface FastifyReply extends HttpErrorReplys {
+  interface FastifyReply extends fastifySensible.HttpErrorReplys {
     vary: {
       (field: string | string[]): void;
       append: (header: string, field: string | string[]) => string;
@@ -94,6 +92,11 @@ declare namespace fastifySensible {
   export type HttpErrors = Errors.HttpErrors;
   export type HttpErrorCodes = Errors.HttpErrorCodes;
   export type HttpErrorNames = Errors.HttpErrorNames;
+
+
+  export type HttpErrorReplys = {
+    getHttpError: (code: HttpErrorCodes, message?: string) => FastifyReply;
+  } & Record<HttpErrorNames, (msg?: string) => FastifyReply>
 
   export const fastifySensible: FastifySensible
   export { fastifySensible as default }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,7 +68,7 @@ declare module 'fastify' {
 declare namespace fastifySensible {
   export interface SensibleOptions {
     /**
-     * You can use this option to register a shared JSON Schema you can use in your routes.
+     * This option registers a shared JSON Schema to be used by all response schemas.
      * 
      * @example
      * ```js

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,12 +73,12 @@ declare namespace fastifySensible {
      * @example
      * ```js
      * fastify.register(require('@fastify/sensible'), {
-     *   sharedSchemaId: 'httpError'
+     *   sharedSchemaId: 'HttpError'
      * })
      *
      * fastify.get('/async', {
      *   schema: {
-     *     response: { 404: { $ref: 'httpError' } }
+     *     response: { 404: { $ref: 'HttpError' } }
      *   }
      *   handler: async (req, reply) => {
      *     return reply.notFound()

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,10 +1,14 @@
-import { expectType, expectAssignable, expectError } from 'tsd'
+import { expectType, expectAssignable, expectError, expectNotAssignable } from 'tsd'
 import fastify from 'fastify'
-import fastifySensible from '..'
+import fastifySensible, { SensibleOptions } from '..'
 
 const app = fastify()
 
 app.register(fastifySensible)
+
+expectAssignable<SensibleOptions>({});
+expectAssignable<SensibleOptions>({ sharedSchemaId: 'HttpError' });
+expectNotAssignable<SensibleOptions>({ notSharedSchemaId: 'HttpError' });
 
 app.get('/', (req, reply) => {
   expectAssignable<typeof reply>(reply.badRequest())


### PR DESCRIPTION
This PR extends #146, as I would like to merge this as quickly as possible, I also added requested type tests and jsdoc.

This also adds exports to 3 types inside `lib/httpError`: `HttpErrorCodes`, `HttpErrorNames` and `HttpErrors`.

Thanks :)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
