### PR TITLE
 feat: export httpErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,3 +81,4 @@ module.exports = fp(fastifySensible, {
 })
 module.exports.default = fastifySensible
 module.exports.fastifySensible = fastifySensible
+module.exports.httpErrors = httpErrors

--- a/lib/httpError.d.ts
+++ b/lib/httpError.d.ts
@@ -99,3 +99,6 @@ export type HttpErrors = {
   getHttpError: (code: HttpErrorCodes, message?: string) => HttpError;
   createError: (...args: UnknownError[]) => HttpError;
 } & Record<HttpErrorNames, (msg?: string) => HttpError>;
+
+declare const HttpErrors: HttpErrors 
+export default HttpErrors;

--- a/test/httpErrors.test.js
+++ b/test/httpErrors.test.js
@@ -1,97 +1,97 @@
-'use strict';
+'use strict'
 
-const { test } = require('tap');
-const createError = require('http-errors');
-const statusCodes = require('node:http').STATUS_CODES;
-const Fastify = require('fastify');
-const Sensible = require('../index');
-const HttpError = require('../lib/httpErrors').HttpError;
+const { test } = require('tap')
+const createError = require('http-errors')
+const statusCodes = require('node:http').STATUS_CODES
+const Fastify = require('fastify')
+const Sensible = require('../index')
+const HttpError = require('../lib/httpErrors').HttpError
 
-test('Should generate the correct http error', (t) => {
-  const fastify = Fastify();
-  fastify.register(Sensible);
+test('Should generate the correct http error', t => {
+  const fastify = Fastify()
+  fastify.register(Sensible)
 
-  fastify.ready((err) => {
-    t.error(err);
+  fastify.ready(err => {
+    t.error(err)
 
-    Object.keys(statusCodes).forEach((code) => {
-      if (Number(code) < 400) return;
-      const name = normalize(code, statusCodes[code]);
-      const err = fastify.httpErrors[name]();
-      t.ok(err instanceof HttpError);
+    Object.keys(statusCodes).forEach(code => {
+      if (Number(code) < 400) return
+      const name = normalize(code, statusCodes[code])
+      const err = fastify.httpErrors[name]()
+      t.ok(err instanceof HttpError)
       // `statusCodes` uses the capital T
-      if (err.message === "I'm a Teapot") {
-        t.equal(err.statusCode, 418);
+      if (err.message === 'I\'m a Teapot') {
+        t.equal(err.statusCode, 418)
       } else {
-        t.equal(err.message, statusCodes[code]);
+        t.equal(err.message, statusCodes[code])
       }
-      t.equal(typeof err.name, 'string');
-      t.equal(err.statusCode, Number(code));
-    });
+      t.equal(typeof err.name, 'string')
+      t.equal(err.statusCode, Number(code))
+    })
 
-    t.end();
-  });
-});
+    t.end()
+  })
+})
 
-test('Should expose the createError method from http-errors', (t) => {
-  const fastify = Fastify();
-  fastify.register(Sensible);
+test('Should expose the createError method from http-errors', t => {
+  const fastify = Fastify()
+  fastify.register(Sensible)
 
-  fastify.ready((err) => {
-    t.error(err);
+  fastify.ready(err => {
+    t.error(err)
 
-    t.equal(fastify.httpErrors.createError, createError);
-    t.end();
-  });
-});
+    t.equal(fastify.httpErrors.createError, createError)
+    t.end()
+  })
+})
 
-test('Should generate the correct error using the properties given', (t) => {
-  const fastify = Fastify();
-  fastify.register(Sensible);
+test('Should generate the correct error using the properties given', t => {
+  const fastify = Fastify()
+  fastify.register(Sensible)
 
-  fastify.ready((err) => {
-    t.error(err);
-    const customError = fastify.httpErrors.createError(404, 'This video does not exist!');
-    t.ok(customError instanceof HttpError);
-    t.equal(customError.message, 'This video does not exist!');
-    t.equal(typeof customError.name, 'string');
-    t.equal(customError.statusCode, 404);
-    t.end();
-  });
-});
+  fastify.ready(err => {
+    t.error(err)
+    const customError = fastify.httpErrors.createError(404, 'This video does not exist!')
+    t.ok(customError instanceof HttpError)
+    t.equal(customError.message, 'This video does not exist!')
+    t.equal(typeof customError.name, 'string')
+    t.equal(customError.statusCode, 404)
+    t.end()
+  })
+})
 
-test('Should generate the correct http error (with custom message)', (t) => {
-  const fastify = Fastify();
-  fastify.register(Sensible);
+test('Should generate the correct http error (with custom message)', t => {
+  const fastify = Fastify()
+  fastify.register(Sensible)
 
-  fastify.ready((err) => {
-    t.error(err);
+  fastify.ready(err => {
+    t.error(err)
 
-    Object.keys(statusCodes).forEach((code) => {
-      if (Number(code) < 400) return;
-      const name = normalize(code, statusCodes[code]);
-      const err = fastify.httpErrors[name]('custom');
-      t.ok(err instanceof HttpError);
-      t.equal(err.message, 'custom');
-      t.equal(typeof err.name, 'string');
-      t.equal(err.statusCode, Number(code));
-    });
+    Object.keys(statusCodes).forEach(code => {
+      if (Number(code) < 400) return
+      const name = normalize(code, statusCodes[code])
+      const err = fastify.httpErrors[name]('custom')
+      t.ok(err instanceof HttpError)
+      t.equal(err.message, 'custom')
+      t.equal(typeof err.name, 'string')
+      t.equal(err.statusCode, Number(code))
+    })
 
-    t.end();
-  });
-});
+    t.end()
+  })
+})
 
 test('should throw error', (t) => {
-  const err = Sensible.httpErrors.conflict('custom');
-  t.equal(err.message, 'custom');
-  t.end();
-});
+  const err = Sensible.httpErrors.conflict('custom')
+  t.equal(err.message, 'custom')
+  t.end()
+})
 
-function normalize(code, msg) {
-  if (code === '414') return 'uriTooLong';
-  if (code === '418') return 'imateapot';
-  if (code === '505') return 'httpVersionNotSupported';
-  msg = msg.split(' ').join('').replace(/'/g, '');
-  msg = msg[0].toLowerCase() + msg.slice(1);
-  return msg;
+function normalize (code, msg) {
+  if (code === '414') return 'uriTooLong'
+  if (code === '418') return 'imateapot'
+  if (code === '505') return 'httpVersionNotSupported'
+  msg = msg.split(' ').join('').replace(/'/g, '')
+  msg = msg[0].toLowerCase() + msg.slice(1)
+  return msg
 }

--- a/test/httpErrors.test.js
+++ b/test/httpErrors.test.js
@@ -1,91 +1,97 @@
-'use strict'
+'use strict';
 
-const { test } = require('tap')
-const createError = require('http-errors')
-const statusCodes = require('node:http').STATUS_CODES
-const Fastify = require('fastify')
-const Sensible = require('../index')
-const HttpError = require('../lib/httpErrors').HttpError
+const { test } = require('tap');
+const createError = require('http-errors');
+const statusCodes = require('node:http').STATUS_CODES;
+const Fastify = require('fastify');
+const Sensible = require('../index');
+const HttpError = require('../lib/httpErrors').HttpError;
 
-test('Should generate the correct http error', t => {
-  const fastify = Fastify()
-  fastify.register(Sensible)
+test('Should generate the correct http error', (t) => {
+  const fastify = Fastify();
+  fastify.register(Sensible);
 
-  fastify.ready(err => {
-    t.error(err)
+  fastify.ready((err) => {
+    t.error(err);
 
-    Object.keys(statusCodes).forEach(code => {
-      if (Number(code) < 400) return
-      const name = normalize(code, statusCodes[code])
-      const err = fastify.httpErrors[name]()
-      t.ok(err instanceof HttpError)
+    Object.keys(statusCodes).forEach((code) => {
+      if (Number(code) < 400) return;
+      const name = normalize(code, statusCodes[code]);
+      const err = fastify.httpErrors[name]();
+      t.ok(err instanceof HttpError);
       // `statusCodes` uses the capital T
-      if (err.message === 'I\'m a Teapot') {
-        t.equal(err.statusCode, 418)
+      if (err.message === "I'm a Teapot") {
+        t.equal(err.statusCode, 418);
       } else {
-        t.equal(err.message, statusCodes[code])
+        t.equal(err.message, statusCodes[code]);
       }
-      t.equal(typeof err.name, 'string')
-      t.equal(err.statusCode, Number(code))
-    })
+      t.equal(typeof err.name, 'string');
+      t.equal(err.statusCode, Number(code));
+    });
 
-    t.end()
-  })
-})
+    t.end();
+  });
+});
 
-test('Should expose the createError method from http-errors', t => {
-  const fastify = Fastify()
-  fastify.register(Sensible)
+test('Should expose the createError method from http-errors', (t) => {
+  const fastify = Fastify();
+  fastify.register(Sensible);
 
-  fastify.ready(err => {
-    t.error(err)
+  fastify.ready((err) => {
+    t.error(err);
 
-    t.equal(fastify.httpErrors.createError, createError)
-    t.end()
-  })
-})
+    t.equal(fastify.httpErrors.createError, createError);
+    t.end();
+  });
+});
 
-test('Should generate the correct error using the properties given', t => {
-  const fastify = Fastify()
-  fastify.register(Sensible)
+test('Should generate the correct error using the properties given', (t) => {
+  const fastify = Fastify();
+  fastify.register(Sensible);
 
-  fastify.ready(err => {
-    t.error(err)
-    const customError = fastify.httpErrors.createError(404, 'This video does not exist!')
-    t.ok(customError instanceof HttpError)
-    t.equal(customError.message, 'This video does not exist!')
-    t.equal(typeof customError.name, 'string')
-    t.equal(customError.statusCode, 404)
-    t.end()
-  })
-})
+  fastify.ready((err) => {
+    t.error(err);
+    const customError = fastify.httpErrors.createError(404, 'This video does not exist!');
+    t.ok(customError instanceof HttpError);
+    t.equal(customError.message, 'This video does not exist!');
+    t.equal(typeof customError.name, 'string');
+    t.equal(customError.statusCode, 404);
+    t.end();
+  });
+});
 
-test('Should generate the correct http error (with custom message)', t => {
-  const fastify = Fastify()
-  fastify.register(Sensible)
+test('Should generate the correct http error (with custom message)', (t) => {
+  const fastify = Fastify();
+  fastify.register(Sensible);
 
-  fastify.ready(err => {
-    t.error(err)
+  fastify.ready((err) => {
+    t.error(err);
 
-    Object.keys(statusCodes).forEach(code => {
-      if (Number(code) < 400) return
-      const name = normalize(code, statusCodes[code])
-      const err = fastify.httpErrors[name]('custom')
-      t.ok(err instanceof HttpError)
-      t.equal(err.message, 'custom')
-      t.equal(typeof err.name, 'string')
-      t.equal(err.statusCode, Number(code))
-    })
+    Object.keys(statusCodes).forEach((code) => {
+      if (Number(code) < 400) return;
+      const name = normalize(code, statusCodes[code]);
+      const err = fastify.httpErrors[name]('custom');
+      t.ok(err instanceof HttpError);
+      t.equal(err.message, 'custom');
+      t.equal(typeof err.name, 'string');
+      t.equal(err.statusCode, Number(code));
+    });
 
-    t.end()
-  })
-})
+    t.end();
+  });
+});
 
-function normalize (code, msg) {
-  if (code === '414') return 'uriTooLong'
-  if (code === '418') return 'imateapot'
-  if (code === '505') return 'httpVersionNotSupported'
-  msg = msg.split(' ').join('').replace(/'/g, '')
-  msg = msg[0].toLowerCase() + msg.slice(1)
-  return msg
+test('should throw error', (t) => {
+  const err = Sensible.httpErrors.conflict('custom');
+  t.equal(err.message, 'custom');
+  t.end();
+});
+
+function normalize(code, msg) {
+  if (code === '414') return 'uriTooLong';
+  if (code === '418') return 'imateapot';
+  if (code === '505') return 'httpVersionNotSupported';
+  msg = msg.split(' ').join('').replace(/'/g, '');
+  msg = msg[0].toLowerCase() + msg.slice(1);
+  return msg;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback, FastifyReply  } from 'fastify'
-import { HttpErrors, HttpErrorCodes, HttpErrorNames } from "../lib/httpError"
+import { HttpErrors } from "../lib/httpError"
 import * as Errors from '../lib/httpError'
 
 type FastifySensible = FastifyPluginCallback<fastifySensible.SensibleOptions>
@@ -92,6 +92,8 @@ declare namespace fastifySensible {
   export type HttpErrors = Errors.HttpErrors;
   export type HttpErrorCodes = Errors.HttpErrorCodes;
   export type HttpErrorNames = Errors.HttpErrorNames;
+
+  export const httpErrors: typeof Errors.default
 
   export type HttpErrorReplys = {
     getHttpError: (code: HttpErrorCodes, message?: string) => FastifyReply;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType, expectAssignable, expectError, expectNotAssignable } from 'tsd'
 import fastify from 'fastify'
-import fastifySensible, { SensibleOptions } from '..'
+import fastifySensible, { SensibleOptions, httpErrors } from '..'
 
 const app = fastify()
 
@@ -149,3 +149,6 @@ app.get('/', async (req, reply) => {
   expectType<string | false | null>(req.is(['foo', 'bar']))
   expectType<string | false | null>(req.is('foo', 'bar'))
 })
+
+httpErrors.forbidden('This type should be also available');
+httpErrors.createError('MyError');


### PR DESCRIPTION
These errors already can be used with `fastify.httpErrors`, however, when writing util functions or functions that will endup inside a route call but are elsewhere, passing the `fastify.httpErrors` as parameters throughout multiple functions is bad. It is already exported from `lib/httpErrors`, this PR just add their types and the index.js `httpErrors` export.

Test for types and js were added.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)