### PR TITLE
fix: declare fastify as peerDependency for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
     "type-is": "^1.6.18",
     "vary": "^1.1.2"
   },
+  "peerDependencies": {
+    "fastify": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
In environments with `pnpm` and `yarn` with `linker: pnpm`, `typescript` fails to resolve the types of `fastify` and can't extend the interfaces of `fastify` properly.

This change declares `fastify` as optional peer dependency since it's only needed for types.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
