### PR TITLE
Export HttpError type

### DIFF
--- a/lib/httpError.d.ts
+++ b/lib/httpError.d.ts
@@ -1,4 +1,4 @@
-interface HttpError extends Error {
+export interface HttpError extends Error {
   status: number;
   statusCode: number;
   expose: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,6 +89,7 @@ declare namespace fastifySensible {
     sharedSchemaId?: string;
   }
 
+  export type HttpError = Errors.HttpError;
   export type HttpErrors = Errors.HttpErrors;
   export type HttpErrorCodes = Errors.HttpErrorCodes;
   export type HttpErrorNames = Errors.HttpErrorNames;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType, expectAssignable, expectError, expectNotAssignable } from 'tsd'
 import fastify from 'fastify'
-import fastifySensible, { SensibleOptions, httpErrors } from '..'
+import fastifySensible, { SensibleOptions, httpErrors, HttpError } from '..'
 
 const app = fastify()
 
@@ -59,6 +59,14 @@ app.get('/', (req, reply) => {
 app.get('/', (req, reply) => {
   expectAssignable<Error>(app.httpErrors.createError(405, 'Method Not Allowed'))
 })
+
+app.get("/", (req, reply) => {
+  expectAssignable<HttpError>(
+    app.httpErrors.createError(405, "Method Not Allowed"),
+  );
+  expectAssignable<HttpError>(app.httpErrors.badRequest());
+});
+
 
 app.get('/', async (req, reply) => {
   expectAssignable<Error>(app.httpErrors.badRequest())


### PR DESCRIPTION
Rexports the HttpError type to fix errors when attempting to use the `httpError` reexport from `@fastify/sensible`.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
