### PR TITLE
perf: replace fast-deep-equal with dequal

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,7 +1,7 @@
 /* eslint-disable eqeqeq */
 'use strict'
 
-const { dequal: deepEqual } = require('dequal');
+const { dequal: deepEqual } = require('dequal')
 const { getHttpError } = require('./httpErrors')
 
 function assert (condition, code, message) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,8 +1,8 @@
 /* eslint-disable eqeqeq */
 'use strict'
 
-const deepEqual = require('fast-deep-equal')
-const getHttpError = require('./httpErrors').getHttpError
+const { dequal: deepEqual } = require('dequal');
+const { getHttpError } = require('./httpErrors')
 
 function assert (condition, code, message) {
   if (condition) return
@@ -32,7 +32,7 @@ assert.deepEqual = function (a, b, code, message) {
 }
 
 assert.notDeepEqual = function (a, b, code, message) {
-  assert(deepEqual(a, b) === false, code, message)
+  assert(!deepEqual(a, b), code, message)
 }
 
 module.exports = assert

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@lukeed/ms": "^2.0.1",
+    "dequal": "^2.0.3",
     "fast-deep-equal": "^3.1.1",
     "fastify-plugin": "^4.0.0",
     "forwarded": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@lukeed/ms": "^2.0.1",
     "dequal": "^2.0.3",
-    "fast-deep-equal": "^3.1.1",
     "fastify-plugin": "^4.0.0",
     "forwarded": "^0.2.0",
     "http-errors": "^2.0.0",


### PR DESCRIPTION
lukeed's `dequal` is amazing, both smaller and [faster](https://github.com/lukeed/dequal?tab=readme-ov-file#benchmarks) than `fast-deep-equal` while being compatible — I think we can slowly migrate to that when possible