### PR TITLE
follow #109 - removed remnants of error handler added by #18

### DIFF
--- a/lib/httpErrors.js
+++ b/lib/httpErrors.js
@@ -134,10 +134,7 @@ const httpErrors = {
   },
 
   internalServerError: function internalServerError (message) {
-    const error = new createError.InternalServerError(message)
-    // mark error as explicit to allow custom message
-    error.explicitInternalServerError = true
-    return error
+    return new createError.InternalServerError(message)
   },
 
   notImplemented: function notImplemented (message) {


### PR DESCRIPTION
#109 dropped the error handler, but there are some remnants of it added by #18 that are not cleaned up.
This PR cleans them up and reverts the changes done by #18.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [ ] ~tests and/or benchmarks are included~
- [ ] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
