### PR TITLE
fix: HttpError exported as type instead of a class

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,3 +82,4 @@ module.exports = fp(fastifySensible, {
 module.exports.default = fastifySensible
 module.exports.fastifySensible = fastifySensible
 module.exports.httpErrors = httpErrors
+module.exports.HttpError = httpErrors.HttpError

--- a/lib/httpErrors.d.ts
+++ b/lib/httpErrors.d.ts
@@ -8,6 +8,10 @@ export interface HttpError extends Error {
   [key: string]: any;
 }
 
+export declare class HttpError {
+  constructor(msg?: string)
+}
+
 type UnknownError = Error | string | number | { [key: string]: any };
 
 export type HttpErrorCodes = 400 | '400' // BadRequest
@@ -95,7 +99,7 @@ export type HttpErrorNames = 'badRequest'
                     | 'networkAuthenticationRequired';
 
 export type HttpErrors = {
-  HttpError: HttpError;
+  HttpError: typeof HttpError;
   getHttpError: (code: HttpErrorCodes, message?: string) => HttpError;
   createError: (...args: UnknownError[]) => HttpError;
 } & Record<HttpErrorNames, (msg?: string) => HttpError>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginCallback, FastifyReply  } from 'fastify'
-import { HttpErrors } from "../lib/httpError"
-import * as Errors from '../lib/httpError'
+import { HttpErrors, HttpError } from "../lib/httpErrors"
+import * as Errors from '../lib/httpErrors'
 
 type FastifySensible = FastifyPluginCallback<fastifySensible.FastifySensibleOptions>
 
@@ -89,7 +89,7 @@ declare namespace fastifySensible {
     sharedSchemaId?: string;
   }
 
-  export type HttpError = Errors.HttpError;
+  export { HttpError }
   export type HttpErrors = Errors.HttpErrors;
   export type HttpErrorCodes = Errors.HttpErrorCodes;
   export type HttpErrorNames = Errors.HttpErrorNames;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

By exporting HttpError as a class it can be used in `instanceof` statements. Fixes #167 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
