### PR TITLE
types(index): allow undefined for optional param

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ declare namespace fastifySensible {
      * })
      * ```
      */
-    sharedSchemaId?: string;
+    sharedSchemaId?: string | undefined;
   }
 
   export { HttpError }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -8,6 +8,7 @@ app.register(fastifySensible)
 
 expectAssignable<FastifySensibleOptions>({})
 expectAssignable<FastifySensibleOptions>({ sharedSchemaId: 'HttpError' })
+expectAssignable<FastifySensibleOptions>({ sharedSchemaId: undefined })
 expectNotAssignable<FastifySensibleOptions>({ notSharedSchemaId: 'HttpError' })
 
 app.get('/', (_req, reply) => {


### PR DESCRIPTION
This PR updates the supports types for the `sharedSchemaId` param to add undefined, because it is able to handle it:

https://github.com/fastify/fastify-sensible/blob/6d5f2a140e52205a4e0ae7a873f92dea72c6ea64/index.js#L56
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
