### PR TITLE
refactor(index): name anonymous functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ function fastifySensible (fastify, opts, next) {
   fastify.decorate('assert', assert)
   fastify.decorate('to', to)
 
-  fastify.decorateRequest('forwarded', function () {
+  fastify.decorateRequest('forwarded', function requestForwarded () {
     return forwarded(this.raw)
   })
 
-  fastify.decorateRequest('is', function (types) {
+  fastify.decorateRequest('is', function requestIs (types) {
     return typeis(this.raw, Array.isArray(types) ? types : [types])
   })
 
@@ -41,13 +41,13 @@ function fastifySensible (fastify, opts, next) {
         // skip abstract class constructor
         break
       case 'getHttpError':
-        fastify.decorateReply('getHttpError', function (errorCode, message) {
+        fastify.decorateReply('getHttpError', function replyGetHttpError (errorCode, message) {
           this.send(httpErrors.getHttpError(errorCode, message))
           return this
         })
         break
       default:
-        fastify.decorateReply(httpError, function (message) {
+        fastify.decorateReply(httpError, function replyHttpError (message) {
           this.send(httpErrors[httpError](message))
           return this
         })

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function fastifySensible (fastify, opts, next) {
         })
         break
       default:
-        fastify.decorateReply(httpError, function replyHttpError (message) {
+        fastify.decorateReply(httpError, function sensibleHttpError (message) {
           this.send(httpErrors[httpError](message))
           return this
         })

--- a/index.js
+++ b/index.js
@@ -46,11 +46,16 @@ function fastifySensible (fastify, opts, next) {
           return this
         })
         break
-      default:
-        fastify.decorateReply(httpError, function sensibleHttpError (message) {
-          this.send(httpErrors[httpError](message))
-          return this
-        })
+      default: {
+        const capitalizedMethodName = httpError.replace(/(?:^|\s)\S/gu, a => a.toUpperCase())
+        const replyMethodName = 'sensible' + capitalizedMethodName
+        fastify.decorateReply(httpError, {
+          [replyMethodName]: function (message) {
+            this.send(httpErrors[httpError](message))
+            return this
+          }
+        }[replyMethodName])
+      }
     }
   }
 


### PR DESCRIPTION
Helps with debugging.

See https://github.com/fastify/otel/issues/110

Before:

<img width="1230" height="194" alt="image" src="https://github.com/user-attachments/assets/f5790938-5f93-402d-b1a2-fef6754efc58" />


After:

<img width="1233" height="229" alt="image" src="https://github.com/user-attachments/assets/d018d09e-f1d5-490d-9c3a-baa147a7519e" />

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
