### PR TITLE
chore: upgrade borp to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@jsumners/line-reporter": "^1.0.1",
     "@types/node": "^25.0.3",
-    "borp": "^0.21.0",
+    "borp": "^1.0.0",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Proposal:

- Upgrade `borp` dependency from `^0.21.0` to `^1.0.0` ( see here: https://github.com/mcollina/borp/releases/tag/v1.0.0 )