### PR TITLE
Fix assert types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,14 +28,14 @@ declare module 'fastify' {
   }
 
   interface Assert {
-    (condition: unknown, code?: number | string, message?: string): asserts condition;
-    ok(condition: unknown, code?: number | string, message?: string): asserts condition;
-    equal(a: unknown, b: unknown, code?: number | string, message?: string): void;
-    notEqual(a: unknown, b: unknown, code?: number | string, message?: string): void;
-    strictEqual<T>(a: unknown, b: T, code?: number | string, message?: string): asserts a is T;
-    notStrictEqual(a: unknown, b: unknown, code?: number | string, message?: string): void;
-    deepEqual(a: unknown, b: unknown, code?: number | string, message?: string): void;
-    notDeepEqual(a: unknown, b: unknown, code?: number | string, message?: string): void;
+    (condition: unknown, code: number, message?: string): asserts condition;
+    ok(condition: unknown, code: number, message?: string): asserts condition;
+    equal(a: unknown, b: unknown, code: number, message?: string): void;
+    notEqual(a: unknown, b: unknown, code: number, message?: string): void;
+    strictEqual<T>(a: unknown, b: T, code: number, message?: string): asserts a is T;
+    notStrictEqual(a: unknown, b: unknown, code: number, message?: string): void;
+    deepEqual(a: unknown, b: unknown, code: number, message?: string): void;
+    notDeepEqual(a: unknown, b: unknown, code: number, message?: string): void;
   }
 
   interface FastifyInstance {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -114,14 +114,15 @@ app.get('/', async () => {
 })
 
 app.get('/', async () => {
-  expectType<void>(app.assert(1))
-  expectType<void>(app.assert.ok(true))
-  expectType<void>(app.assert.equal(1, 1))
-  expectType<void>(app.assert.notEqual(1, 2))
-  expectType<void>(app.assert.strictEqual(1, 1))
-  expectType<void>(app.assert.notStrictEqual(1, 2))
-  expectType<void>(app.assert.deepEqual({}, {}))
-  expectType<void>(app.assert.notDeepEqual({}, { a: 1 }))
+  expectError(app.assert(true))
+  expectType<void>(app.assert(1, 400, 'Bad number'))
+  expectType<void>(app.assert.ok(true, 400))
+  expectType<void>(app.assert.equal(1, 1, 400))
+  expectType<void>(app.assert.notEqual(1, 2, 400))
+  expectType<void>(app.assert.strictEqual(1, 1, 400))
+  expectType<void>(app.assert.notStrictEqual(1, 2, 400))
+  expectType<void>(app.assert.deepEqual({}, {}, 400))
+  expectType<void>(app.assert.notDeepEqual({}, { a: 1 }, 400))
 })
 
 app.get('/', async () => {


### PR DESCRIPTION
This clarifies that assert can be used with 2-3 arguments, but not with a single argument. The second argument must be the status code as a number.

- Fixes #214

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [-] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
