### PR TITLE
fix: add fastify as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "type-is": "^2.0.1",
     "vary": "^1.1.2"
   },
+  "peerDependencies": {
+    "fastify": ">=5.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary

- Adds `fastify` as a `peerDependency` (`>=5.0.0`) to fix type resolution issues in strict package managers like pnpm
- `@fastify/sensible` imports types from `fastify` in its type declarations (`types/index.d.ts`) but only lists it in `devDependencies`
- In pnpm monorepos with multiple fastify versions, this causes incompatible `FastifyInstance` types and TypeScript errors

## Problem

In pnpm (which uses strict isolated `node_modules`), `@fastify/sensible` cannot resolve `fastify` from its own `node_modules` since it's not a declared dependency. Node's resolution algorithm walks up the directory tree and can land on a different version of fastify installed by another workspace package, causing errors like:

```
No overload matches this call.
  Type 'FastifyInstance<..., FastifyTypeProvider>' is missing the following properties
  from type 'FastifyInstance<..., FastifyTypeProviderDefault>': ...
```

## Steps to reproduce

1. Create a pnpm monorepo with two apps depending on different fastify versions (e.g., 5.3.3 and 5.8.4)
2. Install `@fastify/sensible` in one of them
3. Register it with `app.register(fastifySensible)` in a TypeScript file with `skipLibCheck: false`
4. TypeScript fails with the overload error above

## Fix

This is consistent with other `@fastify/*` plugins like `@fastify/cors`, `@fastify/cookie`, `@fastify/helmet`, etc. that already declare fastify as a peer dependency.

## Test plan

- [ ] Existing tests pass (`npm test`)
- [ ] Verify in a pnpm monorepo that the type resolution error is resolved