### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ fastify.get('/', (req, reply) => {
 ```
 
 #### `reply.stale`
-The `reply` interface is decorated with a helper to set the cache control header for [stale content](https://tools.ietf.org/html/rfc5861).
+The `reply` interface is decorated with a helper to set the cache control header for [stale content](https://datatracker.ietf.org/doc/html/rfc5861).
 ```js
 fastify.get('/', (req, reply) => {
   // the time can be defined as a string
@@ -226,7 +226,7 @@ fastify.get('/', (req, reply) => {
 ```
 
 #### `reply.maxAge`
-The `reply` interface is decorated with a helper to set max age of the response. It can be used in conjunction with `reply.stale`, see [here](https://web.dev/stale-while-revalidate/).
+The `reply` interface is decorated with a helper to set max age of the response. It can be used in conjunction with `reply.stale`, see [here](https://web.dev/case-studies/ads-case-study-stale-while-revalidate).
 ```js
 fastify.get('/', (req, reply) => {
   // the time can be defined as a string

--- a/lib/cache-control.js
+++ b/lib/cache-control.js
@@ -4,7 +4,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 // Useful reads:
 // - https://odino.org/http-cache-101-scaling-the-web/
-// - https://web.dev/stale-while-revalidate/
+// - https://web.dev/case-studies/ads-case-study-stale-while-revalidate
 // - https://csswizardry.com/2019/03/cache-control-for-civilians/
 // - https://jakearchibald.com/2016/caching-best-practices/
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71